### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,4 +3,4 @@
 The Unicode Consortium is the standards body for character encoding and internationalization of software and services. Read more [about us](https://unicode.org/).
 Repositories here are maintained by various technical committees, please see [here](https://www.unicode.org/main.html) for information about each commitee.
 
-Copyright © Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries.
+Copyright © 1991-2023 Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries. A CLA is required to contribute to Unicode projects - please refer to the [CONTRIBUTING.md](https://github.com/unicode-org/.github/blob/main/.github/CONTRIBUTING.md) file (or start a Pull Request) for more information.

--- a/profile/README.md
+++ b/profile/README.md
@@ -3,4 +3,4 @@
 The Unicode Consortium is the standards body for character encoding and internationalization of software and services. Read more [about us](https://unicode.org/).
 Repositories here are maintained by various technical committees, please see [here](https://www.unicode.org/main.html) for information about each commitee.
 
-_© Unicode, Inc., see [Terms of Use](https://www.unicode.org/copyright.html)_
+Copyright © Unicode, Inc. Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the United States and other countries.


### PR DESCRIPTION
I noticed that going to https://github.com/unicode-org has the following notice:

<img width="761" alt="image" src="https://github.com/unicode-org/.github/assets/855219/b82d8b6b-ba98-49a4-8df1-7524d641ae3a">

Should we remove the 'terms of use' link? 

This PR changes this message.